### PR TITLE
fix volume permission error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 __pycache__/
+
+sources/tools/*.zip

--- a/compose.yml
+++ b/compose.yml
@@ -5,7 +5,7 @@ services:
     group_add:
       - 1001
     volumes:
-      - /opt/db:/opt/db
+      - db:/opt/db
     command: chown -R 1001:1001 /opt/db
     networks:
       net:
@@ -16,7 +16,7 @@ services:
     - 7687:7687
     - 7473:7473
     volumes:
-    - "/opt/db:/data"
+    - db:/data
     user: 1001:1001
     environment:
       - NEO4J_AUTH=neo4j/${NEO4J_PASSWORD}


### PR DESCRIPTION
Hi, 

This PR fix an error about volume permission at docker startup : 
Before: 
```
docker compose up
[+] Running 6/6
 ✔ Network osaka_net                  Created                                                                                                                              0.1s 
 ✔ Container osaka-database-1         Created                                                                                                                              0.1s 
 ✔ Container osaka-loader-1           Created                                                                                                                              0.1s 
 ✔ Container osaka-editor-1           Created                                                                                                                              0.1s 
 ✔ Container osaka-visualizer-1       Created                                                                                                                              0.1s 
 ✔ Container osaka-volume-perm-job-1  Created                                                                                                                              0.1s 
Attaching to database-1, editor-1, loader-1, visualizer-1, volume-perm-job-1
visualizer-1       | /docker-entrypoint.sh: /docker-entrypoint.d/ is not empty, will attempt to perform configuration
visualizer-1       | /docker-entrypoint.sh: Looking for shell scripts in /docker-entrypoint.d/
visualizer-1       | /docker-entrypoint.sh: Launching /docker-entrypoint.d/10-listen-on-ipv6-by-default.sh
visualizer-1       | 10-listen-on-ipv6-by-default.sh: info: Getting the checksum of /etc/nginx/conf.d/default.conf
Error response from daemon: error while creating mount source path '/opt/db': mkdir /opt/db: read-only file system
```

After: containers starts correctly :)

The `volumes` section inside the compose declares an unused volume, so I assumed it was this one.

Also, if you follow the documentation the zip archives will be generated inside `tools` folder so I add it in the `.gitignore` file

