### PR TITLE
Fix SVC import

### DIFF
--- a/sources/src/Loader/loader.py
+++ b/sources/src/Loader/loader.py
@@ -16,7 +16,11 @@ def services(data, driver):
             if 'loadBalancerIP' in service["spec"]:
                 lbip = service["spec"]["loadBalancerIP"]
             elif 'ingress' in service["status"]["loadBalancer"]:
-                lbip = service["status"]["loadBalancer"]["ingress"][0]["ip"]
+                ingress = service["status"]["loadBalancer"]["ingress"][0]
+                if "ip" in ingress:
+                    lbip = ingress["ip"]
+                elif "hostname" in ingress:
+                    lbip = ingress["hostname"]
 
             query = """
             CREATE (s:Services { Name : $name, Type : $type, Namespace : $ns, ClusterIP : $clusterip, 
@@ -26,9 +30,9 @@ def services(data, driver):
                                  name=service["metadata"]["name"],
                                  type=service["spec"]["type"],
                                  ns=service["metadata"]["namespace"],
-                                 clusterip=service["spec"]["clusterIP"],
+                                 clusterip=service["spec"]["clusterIP"] if "clusterIP" in service["spec"] else None,
                                  lbip=lbip,
-                                 selector=json.dumps(service["spec"]["selector"], indent=2),
+                                 selector=json.dumps(service["spec"].get("selector", {}), indent=2),
                                  ports=json.dumps(service["spec"]["ports"][0], indent=2))
 
         else:
@@ -41,8 +45,8 @@ def services(data, driver):
                                      name=service["metadata"]["name"],
                                      type=service["spec"]["type"],
                                      ns=service["metadata"]["namespace"],
-                                     clusterip=service["spec"]["clusterIP"],
-                                     selector=json.dumps(service["spec"]["selector"]),
+                                     clusterip=service["spec"]["clusterIP"] if "clusterIP" in service["spec"] else None,
+                                     selector=json.dumps(service["spec"].get("selector", {})),
                                      ports=json.dumps(service["spec"]["ports"], indent=2))
             else:
                 query = """
@@ -53,7 +57,7 @@ def services(data, driver):
                                      name=service["metadata"]["name"],
                                      type=service["spec"]["type"],
                                      ns=service["metadata"]["namespace"],
-                                     clusterip=service["spec"]["clusterIP"],
+                                     clusterip=service["spec"]["clusterIP"] if "clusterIP" in service["spec"] else None,
                                      ports=json.dumps(service["spec"]["ports"], indent=2))
 
 


### PR DESCRIPTION
Hi,

I work at DINUM, and I am testing your tool on our cluster for La Suite. During my tests, I encountered some issues with Services (SVC)

- Sometimes, a Service (SVC) may not have a selector, especially when endpoints are managed manually.
- Headless Services may exist without a cluster IP.
- On Outscale, LoadBalancer Services have an ingress["hostname"] field in their status, not ingress["ip"].